### PR TITLE
Fixes bug with difference dates in the same second returning true

### DIFF
--- a/src/diff/index.js
+++ b/src/diff/index.js
@@ -13,7 +13,7 @@ const diff = (lhs, rhs) => {
   }, {});
 
   if (isDate(l) || isDate(r)) {
-    if (l.toString() == r.toString()) return {};
+    if (l.valueOf() == r.valueOf()) return {};
     return r;
   }
 

--- a/src/diff/index.test.js
+++ b/src/diff/index.test.js
@@ -35,6 +35,7 @@ describe('.diff', () => {
         [100, () => ({})],
         [() => ({}), 100],
         [new Date('2017-01-01'), new Date('2017-01-02')],
+        [new Date('2017-01-01T00:00:00.636Z'), new Date('2017-01-01T00:00:00.637Z')],
       ]).test('returns right hand side value when different to left hand side value (%s, %s)', (lhs, rhs) => {
         expect(diff(lhs, rhs)).toEqual(rhs);
       });

--- a/src/updated/index.js
+++ b/src/updated/index.js
@@ -10,7 +10,7 @@ const updatedDiff = (lhs, rhs) => {
   const r = properObject(rhs);
 
   if (isDate(l) || isDate(r)) {
-    if (l.toString() == r.toString()) return {};
+    if (l.valueOf() == r.valueOf()) return {};
     return r;
   }
 

--- a/src/updated/index.test.js
+++ b/src/updated/index.test.js
@@ -35,6 +35,7 @@ describe('.updatedDiff', () => {
         [100, () => ({})],
         [() => ({}), 100],
         [new Date('2017-01-01'), new Date('2017-01-02')],
+        [new Date('2017-01-01T00:00:00.636Z'), new Date('2017-01-01T00:00:00.637Z')],
       ]).test('returns right hand side value when different to left hand side value (%s, %s)', (lhs, rhs) => {
         expect(updatedDiff(lhs, rhs)).toEqual(rhs);
       });


### PR DESCRIPTION
When you check if two dates are equal to each other you run the following code:

if ((0, _utils.isDate)(l) || (0, _utils.isDate)(r)) {
   if (l.toString() == r.toString()) return {};
   return r;
}
The issue here is that new Date(1).toString() === new Date(2).toString() //true which is obviously false.

The issue here is that toString formats the date object into a human readable format which does not take milliseconds into account Mon Sep 28 1998 14:36:22 GMT-0700 (PDT)

What you should be using instead is .valueOf() which converts the date into an epoch time. This is also much more preferment than toStirng: roughly 25x faster in node 7.
