### PR TITLE
remove usage of the 'reduce...spread' pattern

### DIFF
--- a/src/added/index.js
+++ b/src/added/index.js
@@ -7,17 +7,25 @@ const addedDiff = (lhs, rhs) => {
   const l = properObject(lhs);
   const r = properObject(rhs);
 
-  return Object.keys(r).reduce((acc, key) => {
-    if (l.hasOwnProperty(key)) {
-      const difference = addedDiff(l[key], r[key]);
+  let changes = {}
 
-      if (isObject(difference) && isEmpty(difference)) return acc;
+  const rKeys = Object.keys(r)
 
-      return { ...acc, [key]: difference };
+  for (let i = 0; i < rKeys.length; i++) {
+    const key = rKeys[i]
+
+    if (!l.hasOwnProperty(key)) {
+      changes[key] = r[key]
+      continue
     }
+    const difference = addedDiff(l[key], r[key]);
 
-    return { ...acc, [key]: r[key] };
-  }, {});
+    if (isObject(difference) && isEmpty(difference)) continue;
+
+    changes[key] = difference
+  }
+
+  return changes
 };
 
 export default addedDiff;

--- a/src/arrayDiff/index.js
+++ b/src/arrayDiff/index.js
@@ -8,9 +8,18 @@ const diff = (lhs, rhs) => {
   const l = properObject(lhs);
   const r = properObject(rhs);
 
-  const deletedValues = Object.keys(l).reduce((acc, key) => {
-    return r.hasOwnProperty(key) ? acc : { ...acc, [key]: undefined };
-  }, {});
+  let changes = {}
+
+  const lKeys = Object.keys(l)
+
+  for (let i = 0; i < lKeys.length; i++) {
+    const key = lKeys[i]
+
+    if (!r.hasOwnProperty(key)) {
+      changes[key] = undefined
+    }
+  }
+
 
   if (isDate(l) || isDate(r)) {
     if (l.valueOf() == r.valueOf()) return {};
@@ -39,15 +48,24 @@ const diff = (lhs, rhs) => {
     }, deletedValues);
   }
 
-  return Object.keys(r).reduce((acc, key) => {
-    if (!l.hasOwnProperty(key)) return { ...acc, [key]: r[key] }; // return added r key
+  const rKeys = Object.keys(r)
+
+  for (let i = 0; i < rKeys.length; i++) {
+    const key = rKeys[i]
+
+    if (!l.hasOwnProperty(key)) {
+      changes[key] = r[key]
+      continue;
+    }
 
     const difference = diff(l[key], r[key]);
 
-    if (isObject(difference) && isEmpty(difference) && !isDate(difference)) return acc; // return no diff
+    if (isObject(difference) && isEmpty(difference) && !isDate(difference)) continue; // return no diff
 
-    return { ...acc, [key]: difference }; // return updated key
-  }, deletedValues);
+    changes[key] = difference
+  }
+
+  return changes
 };
 
 export default diff;

--- a/src/deleted/index.js
+++ b/src/deleted/index.js
@@ -6,17 +6,25 @@ const deletedDiff = (lhs, rhs) => {
   const l = properObject(lhs);
   const r = properObject(rhs);
 
-  return Object.keys(l).reduce((acc, key) => {
-    if (r.hasOwnProperty(key)) {
-      const difference = deletedDiff(l[key], r[key]);
+  let changes = {}
 
-      if (isObject(difference) && isEmpty(difference)) return acc;
+  const lKeys = Object.keys(l)
 
-      return { ...acc, [key]: difference };
+  for (let i = 0; i < lKeys.length; i++) {
+    const key = lKeys[i]
+
+    if (!r.hasOwnProperty(key)) {
+      changes[key] = undefined
+      continue
     }
+    const difference = deletedDiff(l[key], r[key]);
 
-    return { ...acc, [key]: undefined };
-  }, {});
+    if (isObject(difference) && isEmpty(difference)) continue;
+    
+    changes[key] = difference
+  }
+
+  return changes
 };
 
 export default deletedDiff;

--- a/src/diff/index.js
+++ b/src/diff/index.js
@@ -8,24 +8,41 @@ const diff = (lhs, rhs) => {
   const l = properObject(lhs);
   const r = properObject(rhs);
 
-  const deletedValues = Object.keys(l).reduce((acc, key) => {
-    return r.hasOwnProperty(key) ? acc : { ...acc, [key]: undefined };
-  }, {});
+  let changes = {}
+
+  const lKeys = Object.keys(l)
+
+  for (let i = 0; i < lKeys.length; i++) {
+    const key = lKeys[i]
+
+    if (!r.hasOwnProperty(key)) {
+      changes[key] = undefined
+    }
+  }
 
   if (isDate(l) || isDate(r)) {
     if (l.valueOf() == r.valueOf()) return {};
     return r;
   }
 
-  return Object.keys(r).reduce((acc, key) => {
-    if (!l.hasOwnProperty(key)) return { ...acc, [key]: r[key] }; // return added r key
+  const rKeys = Object.keys(r)
+
+  for (let i = 0; i < rKeys.length; i++) {
+    const key = rKeys[i]
+
+    if (!l.hasOwnProperty(key)) {
+      changes[key] = r[key]
+      continue;
+    }
 
     const difference = diff(l[key], r[key]);
 
-    if (isObject(difference) && isEmpty(difference) && !isDate(difference)) return acc; // return no diff
+    if (isObject(difference) && isEmpty(difference) && !isDate(difference)) continue; // return no diff
 
-    return { ...acc, [key]: difference }; // return updated key
-  }, deletedValues);
+    changes[key] = difference
+  }
+
+  return changes
 };
 
 export default diff;

--- a/src/updated/index.js
+++ b/src/updated/index.js
@@ -14,18 +14,25 @@ const updatedDiff = (lhs, rhs) => {
     return r;
   }
 
-  return Object.keys(r).reduce((acc, key) => {
 
-    if (l.hasOwnProperty(key)) {
-      const difference = updatedDiff(l[key], r[key]);
+  let changes = {}
 
-      if (isObject(difference) && isEmpty(difference) && !isDate(difference)) return acc;
+  const rKeys = Object.keys(r)
 
-      return { ...acc, [key]: difference };
-    }
+  for (let i = 0; i < rKeys.length; i++){
+    const key = rKeys[i]
 
-    return acc;
-  }, {});
+    if (!l.hasOwnProperty(key)) continue
+
+    const difference = updatedDiff(l[key], r[key]);
+
+    if (isObject(difference) && isEmpty(difference) && !isDate(difference)) continue;
+
+    changes[key] = difference
+
+  }
+
+  return changes
 };
 
 export default updatedDiff;


### PR DESCRIPTION
This is a PR in response to #46 .  It aims to improve the speed of the package by removing the usage of the 'reduce...spread' pattern, in favor of traditional for loops.

[Benchmark.js](https://github.com/bestiejs/benchmark.js) stats

added#original x 533,358 ops/sec ±0.70% (92 runs sampled)
added#new x 1,114,933 ops/sec ±0.63% (94 runs sampled)

updated#original x 391,597 ops/sec ±0.97% (91 runs sampled)
updated#new x 1,057,258 ops/sec ±0.47% (95 runs sampled)

deleted#original x 1,299,890 ops/sec ±0.54% (94 runs sampled)
deleted#new x 1,981,737 ops/sec ±1.09% (90 runs sampled)

detailed#original x 203,221 ops/sec ±0.60% (93 runs sampled)
detailed#new x 357,716 ops/sec ±0.36% (85 runs sampled)

diff#original x 244,553 ops/sec ±0.50% (91 runs sampled)
diff#new x 855,466 ops/sec ±0.97% (92 runs sampled)


Reference https://www.richsnapp.com/blog/2019/06-09-reduce-spread-anti-pattern