### PR TITLE
Use triple equals for dates

### DIFF
--- a/src/diff/index.js
+++ b/src/diff/index.js
@@ -13,7 +13,7 @@ const diff = (lhs, rhs) => {
   }, {});
 
   if (isDate(l) || isDate(r)) {
-    if (l.valueOf() == r.valueOf()) return {};
+    if (l.valueOf() === r.valueOf()) return {};
     return r;
   }
 


### PR DESCRIPTION
Not sure what would need to be coerced here, triple equals might help ensure a more accurate diff. 

[sample source](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/valueOf)
```js
const date1 = new Date(Date.UTC(96, 1, 2, 3, 4, 5));

console.log(date1.valueOf());
// expected output: 823230245000

const date2 = new Date("02 Feb 1996 03:04:05 GMT");

console.log(date2.valueOf());
// expected output: 823230245000
```

After looking at this I'm thinking we should use triple equals here.

```js
console.log(date1.valueOf() === date2.valueOf());
// expected output: true
```