### PR TITLE
Remove spread operator in object diffs to increase performance

### DIFF
--- a/src/added.js
+++ b/src/added.js
@@ -13,10 +13,12 @@ const addedDiff = (lhs, rhs) => {
 
       if (isObject(difference) && isEmpty(difference)) return acc;
 
-      return { ...acc, [key]: difference };
+      acc[key] = difference;
+      return acc;
     }
 
-    return { ...acc, [key]: r[key] };
+    acc[key] = r[key];
+    return acc;
   }, {});
 };
 

--- a/src/deleted.js
+++ b/src/deleted.js
@@ -12,10 +12,12 @@ const deletedDiff = (lhs, rhs) => {
 
       if (isObject(difference) && isEmpty(difference)) return acc;
 
-      return { ...acc, [key]: difference };
+      acc[key] = difference;
+      return acc;
     }
 
-    return { ...acc, [key]: undefined };
+    acc[key] = undefined;
+    return acc;
   }, {});
 };
 

--- a/src/diff.js
+++ b/src/diff.js
@@ -9,7 +9,12 @@ const diff = (lhs, rhs) => {
   const r = rhs;
 
   const deletedValues = Object.keys(l).reduce((acc, key) => {
-    return hasOwnProperty(r, key) ? acc : { ...acc, [key]: undefined };
+    if (!hasOwnProperty(r, key)) {
+      acc[key] = undefined;
+      
+    }
+
+    return acc;
   }, {});
 
   if (isDate(l) || isDate(r)) {
@@ -18,7 +23,10 @@ const diff = (lhs, rhs) => {
   }
 
   return Object.keys(r).reduce((acc, key) => {
-    if (!hasOwnProperty(l, key)) return { ...acc, [key]: r[key] }; // return added r key
+    if (!hasOwnProperty(l, key)){
+      acc[key] = r[key]; // return added r key
+      return acc;
+    } 
 
     const difference = diff(l[key], r[key]);
 
@@ -26,7 +34,8 @@ const diff = (lhs, rhs) => {
     if (isEmptyObject(difference) && !isDate(difference) && (isEmptyObject(l[key]) || !isEmptyObject(r[key])))
       return acc; // return no diff
 
-    return { ...acc, [key]: difference }; // return updated key
+    acc[key] = difference // return updated key
+    return acc; // return updated key
   }, deletedValues);
 };
 

--- a/src/updated.js
+++ b/src/updated.js
@@ -21,7 +21,8 @@ const updatedDiff = (lhs, rhs) => {
       if (isEmptyObject(difference) && !isDate(difference) && (isEmptyObject(l[key]) || !isEmptyObject(r[key])))
         return acc; // return no diff
 
-      return { ...acc, [key]: difference };
+      acc[key] = difference;
+      return acc;
     }
 
     return acc;


### PR DESCRIPTION
## Motivation and Context
While using detailedDiff from this library, ran into an issue where large enough files would cause functions to just hang. After updating the object value assignments and removing the spread operator (...), the performance improved. 

****Note** did not remove the spread operator from the array function or smaller utility functions.

![image](https://user-images.githubusercontent.com/56368426/120551006-902f7380-c3c3-11eb-96b1-411652198fcf.png)
 
Relied on the following functions for timing and heap usage:

```
console.time()
console.timeEnd()
process.memoryUsage()

```
 

## How Has This Been Tested?
While making changes, made sure test suite was still good with `npm test` runs