### PR TITLE
Stronger typescript support for  deep-object-diff

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,9 +1,19 @@
-export function diff (originalObj: object, updatedObj: object): object
+type DeepPartial<T> = T extends object ? {
+    [P in keyof T]?: DeepPartial<T[P]>;
+} : T;
 
-export function addedDiff (originalObj: object, updatedObj: object): object
+export function diff <T extends object, J extends object>(originalObj: T, updatedObj: J): DeepPartial<T & J>
 
-export function deletedDiff (originalObj: object, updatedObj: object): object
+export function addedDiff <T extends object, J extends object>(originalObj: T, updatedObj: J): DeepPartial<T & J>
 
-export function updatedDiff (originalObj: object, updatedObj: object): object
+export function deletedDiff <T extends object, J extends object>(originalObj: T, updatedObj: J): DeepPartial<T & J>
 
-export function detailedDiff (originalObj: object, updatedObj: object): object
+export function updatedDiff <T extends object, J extends object>(originalObj: T, updatedObj: J): DeepPartial<T & J>
+
+export interface DetailedDiff<T extends object, J extends object> {
+    added: DeepPartial<T & J>
+    deleted: DeepPartial<T & J>
+    updated: DeepPartial<T & J>
+}
+
+export function detailedDiff <T extends object, J extends object>(originalObj: T, updatedObj: J): DetailedDiff<T & J>


### PR DESCRIPTION
`deep-object-diff` will now type the return type based off of the two objects passed in. 

```ts
  const result = diff(
    {
      some: "value",
      deep: {
        nested: {
          property: "value",
          array: [1, 2, 3],
        },
      },
    },
    { some: "value", other: 1 }
  );

  result.deep.nested.property; // $ExpectType string
  result.some; // $ExpectType string
  result.other; // $ExpectType number
  result.deep.nested.array; // $ExpectType number[]
```