### PR TITLE
Fix typings resolution when using TypeScript 4.7+ with ESM

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
   "exports": {
     ".": {
       "import": "./mjs/index.js",
-      "require": "./cjs/index.js"
+      "require": "./cjs/index.js",
+      "types": "./index.d.ts"
     }
   },
   "types": "./index.d.ts",


### PR DESCRIPTION
TypeScript in ESM mode is trying to use file `index.d.mts` for types but there is no such file. So we need to provide custom path to typings file. Root `types` field is ignored in ESM mode

For reference: same issue in another package https://github.com/telegraf/telegraf/issues/1629#issue-1248403562