### PR TITLE
Added TS generic

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,15 +1,15 @@
-export function diff (originalObj: object, updatedObj: object): object
+export function diff<T extends object>(originalObj: T, updatedObj: T): Partial<T>
 
-export function addedDiff (originalObj: object, updatedObj: object): object
+export function addedDiff<T extends object>(originalObj: T, updatedObj: T): Partial<T>
 
-export function deletedDiff (originalObj: object, updatedObj: object): object
+export function deletedDiff<T extends object>(originalObj: T, updatedObj: T): Partial<T>
 
-export function updatedDiff (originalObj: object, updatedObj: object): object
+export function updatedDiff<T extends object>(originalObj: T, updatedObj: T): Partial<T>
 
-export interface DetailedDiff {
-    added: object
-    deleted: object
-    updated: object
+export interface DetailedDiff<T extends object> {
+    added: Partial<T>
+    deleted: Partial<T>
+    updated: Partial<T>
 }
 
-export function detailedDiff (originalObj: object, updatedObj: object): DetailedDiff
+export function detailedDiff<T extends object>(originalObj: T, updatedObj: T): DetailedDiff<T>


### PR DESCRIPTION
Because there is no way to define the output of the type, and we should avoid `updatedDiff(objectA, objectB) as MyType` we introduce generics. Now we can just do `updatedDiff<MyType>(objectA, objectB)`. Or just `updatedDiff(objectA, objectB)` if the compile can type guessing.